### PR TITLE
Added BeginTx

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -1,6 +1,9 @@
 package gorm
 
-import "database/sql"
+import (
+	"context"
+	"database/sql"
+)
 
 // SQLCommon is the minimal database connection functionality gorm requires.  Implemented by *sql.DB.
 type SQLCommon interface {
@@ -12,6 +15,7 @@ type SQLCommon interface {
 
 type sqlDb interface {
 	Begin() (*sql.Tx, error)
+	BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
 }
 
 type sqlTx interface {

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package gorm
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -512,6 +513,19 @@ func (s *DB) Begin() *DB {
 	c := s.clone()
 	if db, ok := c.db.(sqlDb); ok && db != nil {
 		tx, err := db.Begin()
+		c.db = interface{}(tx).(SQLCommon)
+		c.AddError(err)
+	} else {
+		c.AddError(ErrCantStartTransaction)
+	}
+	return c
+}
+
+// BeginTx begins a transaction with options
+func (s *DB) BeginTx(ctx context.Context, opts *sql.TxOptions) *DB {
+	c := s.clone()
+	if db, ok := c.db.(sqlDb); ok && db != nil {
+		tx, err := db.BeginTx(ctx, opts)
 		c.db = interface{}(tx).(SQLCommon)
 		c.AddError(err)
 	} else {


### PR DESCRIPTION
Allows the use of sql.DB.BeginTx and with it the option to specify the transaction isolation level.

Make sure these boxes checked before submitting your pull request.

- [] Do only one thing
- [] No API-breaking changes
- [] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?
