### PR TITLE
Fixed subquery expression escape

### DIFF
--- a/expression_ext.go
+++ b/expression_ext.go
@@ -536,7 +536,10 @@ func (e *expr) in(operator string, values ...interface{}) *expr {
 			return e
 		}
 		if vexpr, ok := values[0].(*expr); ok {
-			e.expr = "(" + e.expr + operator + " IN (" + vexpr.expr + "))"
+			escapedVExpr := strings.TrimPrefix(vexpr.expr, "(")
+			escapedVExpr = strings.TrimSuffix(escapedVExpr, ")")
+
+			e.expr = "(" + e.expr + operator + " IN (" + escapedVExpr + "))"
 			e.args = append(e.args, vexpr.args...)
 			return e
 		}


### PR DESCRIPTION
Make sure these boxes checked before submitting your pull request.

- [x] Do only one thing
- [x] No API-breaking changes
- [] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?

Due to a syntactical difference within SQLite a statement that is used with e.g. `.SubQuery()` led to a different interpretation. As the `.in` method already wraps the expression in brackets, we can just strip the prefix and suffix brackets.
